### PR TITLE
Sync Translations

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ In case of adding a new text to the content, add the translation to tha that fil
 > npm run sync-trans
 ```
 
-It will add any new or missing translations to other translatio files.
+It will add any new or missing translations to other translation files.
 
 
 ## License

--- a/README.md
+++ b/README.md
@@ -5,3 +5,20 @@ Source code of Savand Bros website.
 ## Development
 
 Install hugo and type `hugo server -D` for live reload or `hugo` to build to `/public`.
+
+## Translations
+
+All the translation files are located under `i18n/` directory and the source of localizations is `i18n/en.json`.
+
+In case of adding a new text to the content, add the translation to tha that file and once you're done, make sure to run the `sync-trans` command to sync all the translation files.
+
+```bash
+> npm run sync-trans
+```
+
+It will add any new or missing translations to other translatio files.
+
+
+## License
+
+Savandbros.com website source code is licensed and distributed under GPLv3.

--- a/package.json
+++ b/package.json
@@ -1,4 +1,7 @@
 {
+  "scripts": {
+    "sync-trans": "node scripts/sync_trans.js"
+  },
   "devDependencies": {
     "gulp": "^3.9.1",
     "gulp-exec": "^3.0.2",

--- a/scripts/sync_trans.js
+++ b/scripts/sync_trans.js
@@ -1,0 +1,160 @@
+#!/usr/bin/env node
+
+/**
+ * SyncTrans
+ *
+ * Will sync all the translation files from the source (English).
+ *
+ * In simple words, when source language has new strings/ids to be translated, it will add those to translation files
+ * so they don't become outdated.
+ *
+ * When the source translation contains:
+ *
+ * en.json
+ * ```json
+ * [
+ *   {
+ *     "id": "savand_bros",
+ *     "translation": "Savand Bros"
+ *   },
+ *   {
+ *     "id": "create_website",
+ *     "translation": "Create a Website"
+ *   },
+ *   {
+ *     "id": "start_blog",
+ *     "translation": "Start a Blog"
+ *   },
+ * ]
+ * ```
+ *
+ * While target translation contains:
+ *
+ * fa.json
+ * ```json
+ * [
+ *   {
+ *     "id": "savand_bros",
+ *     "translation": "ساوند بروز"
+ *   },
+ *   {
+ *    "id": "create_website",
+ *    "translation": "ساخت یک وبسایت"
+ *   }
+ * ]
+ * ```
+ *
+ * It wil turn the `fa.json` translation file into:
+ *
+ * fa.json
+ * ```json
+ * [
+ *   {
+ *     "id": "savand_bros",
+ *     "translation": "ساوند بروز"
+ *   },
+ *   {
+ *    "id": "create_website",
+ *    "translation": "ساخت یک وبسایت"
+ *   },
+ *   {
+ *     "id": "start_blog",
+ *     "translation": "Start a Blog"
+ *   }
+ * ]
+ * ```
+ */
+const fs = require('fs');
+const SOURCE_LOCALE = 'en';
+const targetlocales = ['fa', 'ru'];
+
+/**
+ * flattenTrans
+ *
+ * Turn the given list of translation in format of [{id: "transId", translation: "Trnslation text"}, ...]
+ * inot a flatten array that is easy to look up, like: {transId: "Trnslation text", ...}.
+ *
+ * @param {Array.<Object.<String, String>>} translationData
+ * @returns {Object.<String, String>}
+ */
+function flattenTrans(translationData) {
+  let flattenTranslation = {};
+
+  for (let key in translationData) {
+    if (!translationData.hasOwnProperty(key)) {
+      continue;
+    }
+
+    let tranlation = translationData[key];
+    flattenTranslation[tranlation.id] = tranlation.translation;
+  }
+
+  return flattenTranslation;
+}
+
+/**
+ * flatten2ListTrans
+ *
+ * Turn a flatten list of translation from {transId: "Trnslation text", ...}
+ * into [{id: "transId", translation: "Trnslation text"}, ...]
+ *
+ * to be compatible with Hugo i18n formaat.
+ *
+ * @param {Object.<String, String>}  flattenTrans 
+ * @returns {Array.<Object.<String, String>>}
+ */
+function flatten2ListTrans(flattenTrans) {
+  let listTrans = [];
+
+  for (let key in flattenTrans) {
+    if (!flattenTrans.hasOwnProperty(key)) {
+      continue;
+    }
+
+    listTrans.push({ id: key, translation: flattenTrans[key] });
+  }
+
+  return listTrans;
+}
+
+fs.readFile(`i18n/${SOURCE_LOCALE}.json`, 'utf8', function (err, data) {
+  if (err) {
+    throw err;
+  }
+
+  const sourceTrans = JSON.parse(data);
+  const flattenSourceTrans = flattenTrans(sourceTrans);
+
+
+  targetlocales.forEach(function (targetLocale) {
+    let targetTransFileName = `i18n/${targetLocale}.json`;
+
+    fs.readFile(targetTransFileName, 'utf8', function (err, data) {
+      if (err) {
+        throw err;
+      }
+
+      let targetTrans = JSON.parse(data);
+      let flattemTargetTrans = flattenTrans(targetTrans);
+
+
+      for (let key in flattenSourceTrans) {
+        if (!flattenSourceTrans.hasOwnProperty(key)) {
+          continue;
+        }
+
+        if (!flattemTargetTrans.hasOwnProperty(key)) {
+          flattemTargetTrans[key] = flattenSourceTrans[key]
+        }
+      }
+
+      fs.writeFile(targetTransFileName, JSON.stringify(flatten2ListTrans(flattemTargetTrans), null, 2) + '\n', function (err) {
+        if (err) {
+          throw err;
+        }
+
+        console.log(`Synced Locale ${targetLocale}!`);
+      });
+    });
+  });
+});


### PR DESCRIPTION
 **SyncTrans**

Will sync all the translation files from the source (English).

In simple words, when source language has new strings/ids to be translated, it will add those to translation files
so they don't become outdated.

When the source translation contains:

en.json
```json
[
  {
    "id": "savand_bros",
    "translation": "Savand Bros"
  },
  {
    "id": "create_website",
    "translation": "Create a Website"
  },
  {
    "id": "start_blog",
    "translation": "Start a Blog"
  },
]
```

While target translation contains:

fa.json
```json
[
  {
    "id": "savand_bros",
    "translation": "ساوند بروز"
  },
  {
  "id": "create_website",
  "translation": "ساخت یک وبسایت"
  }
]
```

It wil turn the `fa.json` translation file into:

fa.json
```json
[
  {
    "id": "savand_bros",
    "translation": "ساوند بروز"
  },
  {
  "id": "create_website",
  "translation": "ساخت یک وبسایت"
  },
  {
    "id": "start_blog",
    "translation": "Start a Blog"
  }
]
```

npm script:

```bash
> npm run sync-trans
```